### PR TITLE
Fix parsing non-chords

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -93,7 +93,10 @@ var ChordFiddle = function () {
     value: function processChord(item, processor) {
       if (item instanceof _chordsheetjs2.default.ChordLyricsPair && item.chords) {
         var parsedChord = _chordjs2.default.parse(item.chords);
-        item.chords = processor(parsedChord).toString();
+
+        if (parsedChord) {
+          item.chords = processor(parsedChord).toString();
+        }
       }
     }
   }, {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 
-<html lang="en"></html><head><meta charset="utf-8" /><title>ChordFiddle</title><meta name="description" content="ChordPro editor. Transpose your chord sheet. Convert ChordPro to chord sheet." /><meta name="keywords" content="javascript, chords, parsing, convert, chord-sheet, chordpro" /><link rel="stylesheet" href="bundle.css?v=1506968844000" /></head><body><header><div class="wrapper"><h1 class="site-name"><a>ChordFiddle</a></h1><ul class="meta"><li>Version 1.1.1</li><li>Built with <a href="https://github.com/martijnversluis/ChordSheetJS" target="_blank">ChordSheetJS</a> and <a href="https://github.com/martijnversluis/ChordJS" target="_blank">ChordJS</a></li><li><a href="https://github.com/martijnversluis/chordfiddle" target="_blank">GitHub</a></li><li><a href="https://github.com/martijnversluis/chordfiddle/issues" target="_blank">Issues</a></li><li><a href="#readme">About</a></li></ul></div></header><main><div class="columns"><section class="column column-left"><ul class="mod-toolbar"><li><button data-id="transpose-down">Transpose down</button></li><li><button data-id="transpose-up">Transpose up</button></li><li><button data-id="switch-to-sharp">Use ♯</button></li><li><button data-id="switch-to-flat">Use ♭</button></li></ul><textarea data-id="chordProEditor" class="sheet-editor active">{title: Let it be}
+<html lang="en"></html><head><meta charset="utf-8" /><title>ChordFiddle</title><meta name="description" content="ChordPro editor. Transpose your chord sheet. Convert ChordPro to chord sheet." /><meta name="keywords" content="javascript, chords, parsing, convert, chord-sheet, chordpro" /><link rel="stylesheet" href="bundle.css?v=1508571584000" /></head><body><header><div class="wrapper"><h1 class="site-name"><a>ChordFiddle</a></h1><ul class="meta"><li>Version 1.1.1</li><li>Built with <a href="https://github.com/martijnversluis/ChordSheetJS" target="_blank">ChordSheetJS</a> and <a href="https://github.com/martijnversluis/ChordJS" target="_blank">ChordJS</a></li><li><a href="https://github.com/martijnversluis/chordfiddle" target="_blank">GitHub</a></li><li><a href="https://github.com/martijnversluis/chordfiddle/issues" target="_blank">Issues</a></li><li><a href="#readme">About</a></li></ul></div></header><main><div class="columns"><section class="column column-left"><ul class="mod-toolbar"><li><button data-id="transpose-down">Transpose down</button></li><li><button data-id="transpose-up">Transpose up</button></li><li><button data-id="switch-to-sharp">Use ♯</button></li><li><button data-id="switch-to-flat">Use ♭</button></li></ul><textarea data-id="chordProEditor" class="sheet-editor active">{title: Let it be}
 {subtitle: ChordSheetJS example version}
 {Chorus}
 
@@ -32,7 +32,7 @@ future features.</p>
 <li>commit and push your changes</li>
 <li>open a pull request</li>
 </ul>
-</div></section><script src="bundle.js?v=1506885551000"></script>
+</div></section><script src="bundle.js?v=1508571583000"></script>
 <script type="text/javascript">
 //<![CDATA[
 if (window.location.hostname == 'martijnversluis.github.io') {

--- a/js/chord_pro_editor.js
+++ b/js/chord_pro_editor.js
@@ -54,7 +54,10 @@ export default class ChordFiddle {
   processChord(item, processor) {
     if (item instanceof ChordSheetJS.ChordLyricsPair && item.chords) {
       const parsedChord = Chord.parse(item.chords);
-      item.chords = processor(parsedChord).toString();
+
+      if (parsedChord) {
+        item.chords = processor(parsedChord).toString();
+      }
     }
   }
 


### PR DESCRIPTION
Transposing would not work when one item inside [] brackets could not be
parsed as a chord

Example:

```
[Intro: ] [A] [D]
```