### PR TITLE
fix: allow scrolling panels

### DIFF
--- a/src/sass/App.sass
+++ b/src/sass/App.sass
@@ -37,6 +37,7 @@
 
     &--grow
       flex-grow: 1
+      min-height: 0
 
     &--relative
       position: relative

--- a/src/sass/ChordSheetViewer.sass
+++ b/src/sass/ChordSheetViewer.sass
@@ -7,7 +7,7 @@
 
   background-color: $viewer-background
   color: $viewer-foreground
-  flex: 1 0 auto
+  flex: 1 1 auto
   overflow: auto
   padding: $viewer-padding
   white-space: pre


### PR DESCRIPTION
Before this patch, the left and right panel didn't allow scrolling when long chord sheets were loaded.