### PR TITLE
ci: deploy temporary review apps for each PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ci-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,32 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install and Build
+        if: github.event.action != 'closed'
+        run: yarn install && yarn build
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./dist/
+          preview-branch: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,18 @@ on:
     branches:
       - master
 
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      tag: ${{ github.ref_name }}
+    permissions:
+      contents: write
+    environment:
+      name: github-pages
+      url: https://${{ github.repository_owner }}.github.io/ChordFiddle/
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -18,24 +24,11 @@ jobs:
         run: corepack enable
       - name: Build
         run: yarn install && yarn build
-      - name: Test
+      - name: Smoke test
         run: cat dist/bundle.js && cat dist/index.html
-      - name: Upload static files as artifact
-        id: deployment
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
-        id: deployment
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          branch: gh-pages
+          clean-exclude: pr-preview


### PR DESCRIPTION
Replace the Actions-based Pages deployment (upload-pages-artifact + deploy-pages) with a branch-based approach using
JamesIves/github-pages-deploy-action. This allows PR previews to be deployed as subdirectories on the gh-pages branch, accessible at https://{owner}.github.io/ChordFiddle/pr-preview/pr-{number}/.

Add preview.yml using rossjrw/pr-preview-action which handles deployment, sticky PR comments, and automatic cleanup on PR close. Add concurrency groups across all workflows to cancel stale runs. Restore environment tracking and smoke-test step in release.yml. Remove the prior Surge.sh and cleanup-preview.yml approach.