### PR TITLE
Bump chordsheetjs from 15.6.0 to 15.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@chordbook/editor": "^0.0.7",
-    "chordsheetjs": "^15.6.0",
+    "chordsheetjs": "^15.6.1",
     "luna-object-viewer": "^0.3.2",
     "lz-string": "^1.5.0",
     "query-string": "^9.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,7 +1930,7 @@ __metadata:
   dependencies:
     "@chordbook/editor": "npm:^0.0.7"
     babel-eslint: "npm:^10.1.0"
-    chordsheetjs: "npm:^15.6.0"
+    chordsheetjs: "npm:^15.6.1"
     css-loader: "npm:^7.1.4"
     eslint: "npm:^10.6.0"
     eslint-config-airbnb-base: "npm:^15.0.0"
@@ -1949,15 +1949,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"chordsheetjs@npm:^15.6.0":
-  version: 15.6.0
-  resolution: "chordsheetjs@npm:15.6.0"
+"chordsheetjs@npm:^15.6.1":
+  version: 15.6.1
+  resolution: "chordsheetjs@npm:15.6.1"
   peerDependencies:
     jspdf: ^4.0.0
   peerDependenciesMeta:
     jspdf:
       optional: true
-  checksum: 10c0/867b7441292ecc389d9b938567a0798b53ecb76aa412e8dc5660d76d89a6fef1c8e0ced1f66ee93d78385ca758aa7328a62b12343bf6c6b18fffdad0d4aabf9c
+  checksum: 10c0/a2414b604e39b82e8367c5cf39e72aa5dfdded61a8edc4ac4788ebf63d5b87b314977fed5c8857f829d4b67b8a1840d22c5b7059f42cf90115eac9c497de64c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Includes the fix for [chordsheetjs#2222](https://github.com/martijnversluis/ChordSheetJS/issues/2222): the label from `{start_of_chorus: LABEL}` is now kept when `{chorus}` (without its own label) is expanded.